### PR TITLE
Added sample script for GCP training.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,37 @@ Food recognition and volume estimation to produce caloric data.
 git clone https://github.com/Liang-yc/ECUSTFD-resized-.git ../
 ```
 
+## Set Up GCP
+
+This guide assumes you have a GCP account created and is made specifically for the chowdr project.
+
+1.  `python3 -m pip install tensorflow_cloud` and install any other relevant dependencies.
+
+2.  Create a GCP Project called `chowder-bucket` using this 
+[guide](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+
+3.  Set your project as the active project, using the ID found [here](https://console.cloud.google.com/).
+
+Optionally, using:
+```
+export PROJECT_ID=<your-project-id>
+gcloud config set project $PROJECT_ID
+```
+
+4.  Enable [AI Platform Services](https://console.cloud.google.com/apis/library/ml.googleapis.com?q=ai&id=2019ad60-5180-4001-9a93-e99871e3207b) for your project.
+
+5.  Enable [Cloud Build API](https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com?q=cloud%20build&id=9472915e-c82c-4bef-8a6a-34c81e5aebcc) for your project.
+
+6.  Create a service account using this [guide](https://cloud.google.com/iam/docs/creating-managing-service-accounts).
+
+7.  Generate an authentication key for the service account. Download it and create the key environment variable.
+
+```
+export GOOGLE_APPLICATION_CREDENTIALS=~/<key-name>.json
+```
+
+Now you are ready to train/test using GCP. Look at the scripts below to help you.
+
 ## Scripts
 
 All scripts are run from the main directory.
@@ -26,6 +57,19 @@ Example:
 
 ``` bash
 python3 scripts/preprocessing/kfold_partition_dataset.py -i ../ECUSTFD-resized-/JPEGImages/ -o workspace/ -k 5
+```
+
+### Running test training on GCP
+
+Follow the instructions above to set up GCP, then run this script from the main directory.
+
+`scripts/gcp/requirements.txt` is necessary for the running of this script. It is a list of python
+packages that the model depends on.
+
+Change the `GCP_BUCKET` variable in the script to match your bucket name if it is not already `chowdr-bucket`.
+
+```bash
+python3 scripts/gcp/test_gcp_train.py
 ```
 
 ### Running Test Images on Pre-Trained Object Detectors

--- a/scripts/gcp/requirements.txt
+++ b/scripts/gcp/requirements.txt
@@ -1,0 +1,2 @@
+tensorflow-datasets
+matplotlib

--- a/scripts/gcp/test_gcp_train.py
+++ b/scripts/gcp/test_gcp_train.py
@@ -1,0 +1,155 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import os
+
+#import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+import tensorflow_cloud as tfc
+import tensorflow_datasets as tfds
+
+from tensorflow import keras
+from tensorflow.keras import layers
+from tensorflow.keras.models import Model
+
+# Set Cloud GCP bucket name
+GCP_BUCKET = "chowdr-bucket"
+MODEL_PATH = "resnet-dogs"
+
+# Setup dataset
+(ds_train, ds_test), metadata = tfds.load(
+    "stanford_dogs",
+    split=["train", "test"],
+    shuffle_files=True,
+    with_info=True,
+    as_supervised=True,
+)
+
+NUM_CLASSES = metadata.features["label"].num_classes
+print("Number of training samples: %d" % tf.data.experimental.cardinality(ds_train))
+print("Number of test samples: %d" % tf.data.experimental.cardinality(ds_test))
+print("Number of classes: %d" % NUM_CLASSES)
+
+# Visualize dataset
+#plt.figure(figsize=(10, 10))
+#for i, (image, label) in enumerate(ds_train.take(9)):
+#    ax = plt.subplot(3, 3, i + 1)
+#    plt.imshow(image)
+#    plt.title(int(label))
+#    plt.axis("off")
+#    plt.savefig("data/test_gcp_train.png")
+
+# Preprocess dataset
+print("Preprocess data.")
+IMG_SIZE = 224
+BATCH_SIZE = 64
+BUFFER_SIZE = 2
+
+size = (IMG_SIZE, IMG_SIZE)
+ds_train = ds_train.map(lambda image, label: (tf.image.resize(image, size), label))
+ds_test = ds_test.map(lambda image, label: (tf.image.resize(image, size), label))
+
+
+def input_preprocess(image, label):
+    image = tf.keras.applications.resnet50.preprocess_input(image)
+    return image, label
+
+
+ds_train = ds_train.map(
+    input_preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE
+)
+ds_train = ds_train.batch(batch_size=BATCH_SIZE, drop_remainder=True)
+ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)
+
+ds_test = ds_test.map(input_preprocess)
+ds_test = ds_test.batch(batch_size=BATCH_SIZE, drop_remainder=True)
+
+# Build the model
+print("Build the model.")
+inputs = tf.keras.layers.Input(shape=(IMG_SIZE, IMG_SIZE, 3))
+base_model = tf.keras.applications.ResNet50(
+    weights="imagenet", include_top=False, input_tensor=inputs
+)
+x = tf.keras.layers.GlobalAveragePooling2D()(base_model.output)
+x = tf.keras.layers.Dropout(0.5)(x)
+outputs = tf.keras.layers.Dense(NUM_CLASSES)(x)
+
+model = tf.keras.Model(inputs, outputs)
+
+# Freeze base model
+base_model.trainable = False
+
+# Setup callbacks
+checkpoint_path = os.path.join("gs://", GCP_BUCKET, MODEL_PATH, "save_at_{epoch}")
+tensorboard_path = os.path.join(
+    "gs://", GCP_BUCKET, "logs", datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+)
+callbacks = [
+    tf.keras.callbacks.ModelCheckpoint(checkpoint_path),
+    tf.keras.callbacks.TensorBoard(log_dir=tensorboard_path, histogram_freq=1),
+    tf.keras.callbacks.EarlyStopping(monitor="val_loss", patience=3),
+]
+
+# Compile model
+print("Compile model.")
+optimizer = tf.keras.optimizers.Adam(learning_rate=1e-2)
+model.compile(
+    optimizer=optimizer,
+    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+    metrics=["accuracy"],
+)
+
+# Train the model.
+print("Train the model")
+if tfc.remote():
+    epochs = 500
+    train_data = ds_train
+    test_data = ds_test
+else:
+    epochs = 1
+    train_data = ds_train.take(5)
+    test_data = ds_test.take(5)
+    callbacks = None
+
+model.fit(
+    train_data, epochs=epochs, callbacks=callbacks, validation_data=test_data, verbose=2
+)
+
+# Calling `tfc.run` with `auto` distribution strategy with multi-gpu
+# chief_config. This will automate TensorFlow Mirrored distribution
+# strategy when training this model.
+# Tip: Move this call to the top of this file if you do not want to
+# train your model locally first.
+print("Create Docker image in bucket.")
+tfc.run(
+    requirements_txt="scripts/gcp/requirements.txt",
+    chief_config=tfc.MachineConfig(
+        cpu_cores=8,
+        memory=30,
+        accelerator_type=tfc.AcceleratorType.NVIDIA_TESLA_T4,
+        accelerator_count=2,
+    ),
+    #docker_config=tfc.DockerConfig(image_build_bucket=GCP_BUCKET),
+    docker_image_bucket_name=GCP_BUCKET,
+)
+
+# Save, load and evaluate the model
+print("Load and evaluate the model.")
+if tfc.remote():
+    SAVE_PATH = os.path.join("gs://", GCP_BUCKET, MODEL_PATH)
+    model.save(SAVE_PATH)
+    model = tf.keras.models.load_model(SAVE_PATH)
+model.evaluate(test_data)


### PR DESCRIPTION
**Note:**
- **SET UP YOUR BUCKETS USING OREGON - us-west1**. I ran into a lot of issues using central (ie. insufficient resources) and I can confirm us-west1 works fine. More info on regions [here](https://cloud.google.com/ai-platform/training/docs/regions).
- Based off of [this tutorial](https://blog.tensorflow.org/2020/08/train-your-tensorflow-model-on-google.html) and script is originally from [here](https://github.com/tensorflow/cloud/blob/master/src/python/tensorflow_cloud/core/tests/examples/call_run_within_script_with_keras_fit.py)
- You may need to do the following otherwise you get a nice `AssertionError: wrong color format 'var(--jp-mirror-editor-variable-color)'` error:
```
python3 -m pip install pygments==2.6.1
python3 -m pip install nbconvert==6.0.0rc0
```
- Follow the GCP set up instructions, then run the script and everything should work.
- My command line did not run the evaluating bit of code, but your job on GCP should.
- `.pb` files get saved into the bucket you created.

**Changes:**
![image](https://user-images.githubusercontent.com/15057839/99129928-f0ec8f80-25dc-11eb-819f-abbcddf22a18.png)
- New script to run and train dogs or something on GCP.
- `requirements.txt` needs to be in the same folder as the script.
- Commented out some unnecessary plotting that I couldn't get working. It's like not useful, but if we want the code, it's there.

